### PR TITLE
feat: Add support for custom headers via OPENAPI_MCP_HEADERS env var

### DIFF
--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -2,7 +2,7 @@ import { MCPProxy } from '../proxy'
 import { OpenAPIV3 } from 'openapi-types'
 import { HttpClient } from '../../client/http-client'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock the dependencies
 vi.mock('../../client/http-client')

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -123,11 +123,86 @@ describe('MCPProxy', () => {
     })
   })
 
+  describe('parseHeadersFromEnv', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should parse valid JSON headers from env', () => {
+      process.env.OPENAPI_MCP_HEADERS = JSON.stringify({
+        'Authorization': 'Bearer token123',
+        'X-Custom-Header': 'test'
+      });
+
+      const proxy = new MCPProxy('test-proxy', mockOpenApiSpec);
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {
+            'Authorization': 'Bearer token123',
+            'X-Custom-Header': 'test'
+          }
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should return empty object when env var is not set', () => {
+      delete process.env.OPENAPI_MCP_HEADERS;
+
+      const proxy = new MCPProxy('test-proxy', mockOpenApiSpec);
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {}
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should return empty object and warn on invalid JSON', () => {
+      const consoleSpy = vi.spyOn(console, 'warn');
+      process.env.OPENAPI_MCP_HEADERS = 'invalid json';
+
+      const proxy = new MCPProxy('test-proxy', mockOpenApiSpec);
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {}
+        }),
+        expect.anything()
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to parse OPENAPI_MCP_HEADERS environment variable:',
+        expect.any(Error)
+      );
+    });
+
+    it('should return empty object and warn on non-object JSON', () => {
+      const consoleSpy = vi.spyOn(console, 'warn');
+      process.env.OPENAPI_MCP_HEADERS = '"string"';
+
+      const proxy = new MCPProxy('test-proxy', mockOpenApiSpec);
+      expect(HttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {}
+        }),
+        expect.anything()
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:',
+        'string'
+      );
+    });
+  });
   describe('connect', () => {
     it('should connect to transport', async () => {
       const mockTransport = {} as Transport
       await proxy.connect(mockTransport)
-      
+
       const server = (proxy as any).server
       expect(server.connect).toHaveBeenCalledWith(mockTransport)
     })

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -202,6 +202,7 @@ describe('MCPProxy', () => {
     it('should connect to transport', async () => {
       const mockTransport = {} as Transport
       await proxy.connect(mockTransport)
+
       const server = (proxy as any).server
       expect(server.connect).toHaveBeenCalledWith(mockTransport)
     })

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -202,7 +202,6 @@ describe('MCPProxy', () => {
     it('should connect to transport', async () => {
       const mockTransport = {} as Transport
       await proxy.connect(mockTransport)
-
       const server = (proxy as any).server
       expect(server.connect).toHaveBeenCalledWith(mockTransport)
     })

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -11,6 +11,7 @@ import { HttpClient, HttpClientError } from '../client/http-client'
 import { OpenAPIV3 } from 'openapi-types'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 
+
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject
   put?: OpenAPIV3.OperationObject
@@ -19,7 +20,7 @@ type PathItemObject = OpenAPIV3.PathItemObject & {
   patch?: OpenAPIV3.OperationObject
 }
 
-type NewToolDefinition = { 
+type NewToolDefinition = {
   methods: Array<{
     name: string;
     description: string;
@@ -46,8 +47,11 @@ export class MCPProxy {
     if (!baseUrl) {
       throw new Error('No base URL found in OpenAPI spec');
     }
-    this.httpClient = new HttpClient({ baseUrl }, openApiSpec)
-    
+    this.httpClient = new HttpClient({
+      baseUrl,
+      headers: this.parseHeadersFromEnv()
+    }, openApiSpec)
+
     // Convert OpenAPI spec to MCP tools
     const converter = new OpenAPIToMCPConverter(openApiSpec)
     const { tools, openApiLookup } = converter.convertToMCPTools();
@@ -130,6 +134,24 @@ export class MCPProxy {
     return this.openApiLookup[operationId] ?? null
   }
 
+  private parseHeadersFromEnv(): Record<string, string> {
+    const headersJson = process.env.OPENAPI_MCP_HEADERS;
+    if (!headersJson) {
+      return {};
+    }
+
+    try {
+      const headers = JSON.parse(headersJson);
+      if (typeof headers !== 'object' || headers === null) {
+        console.warn('OPENAPI_MCP_HEADERS environment variable must be a JSON object, got:', typeof headers);
+        return {};
+      }
+      return headers;
+    } catch (error) {
+      console.warn('Failed to parse OPENAPI_MCP_HEADERS environment variable:', error);
+      return {};
+    }
+  }
   private getContentType(headers: Headers): 'text' | 'image' | 'binary' {
     const contentType = headers.get('content-type')
     if (!contentType) return 'binary'
@@ -146,4 +168,4 @@ export class MCPProxy {
     // The SDK will handle stdio communication
     await this.server.connect(transport)
   }
-} 
+}

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -152,6 +152,7 @@ export class MCPProxy {
       return {};
     }
   }
+
   private getContentType(headers: Headers): 'text' | 'image' | 'binary' {
     const contentType = headers.get('content-type')
     if (!contentType) return 'binary'


### PR DESCRIPTION
Add ability to pass custom headers to HTTP requests through environment variables. Headers can be specified as a JSON object in OPENAPI_MCP_HEADERS.

- Added parseHeadersFromEnv method to handle header parsing
- Added comprehensive test coverage for header parsing
- Handles invalid JSON and non-object values gracefully with warnings
- Default to empty headers if env var not set

Example usage:

```
{
  "mcpServers": {
    "openapi": {
      "command": "npx",
      "args": ["-y", "openapi-mcp-server", "http://yourdomain.com/openapi.json"],
      "env": {
        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer TOKEN\"}"
      }
    }
  }
}
```

ref #4  #1 