### PR TITLE
Add YAML support

### DIFF
--- a/examples/cli/__tests__/openapi-client.test.ts
+++ b/examples/cli/__tests__/openapi-client.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs/promises'
+import axios from 'axios'
+import yaml from 'js-yaml'
+import { loadSpec } from '../openapi-client'
+
+vi.mock('fs/promises')
+vi.mock('axios')
+
+const validOpenApiSpec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Test API',
+    version: '1.0.0'
+  },
+  servers: [{ url: 'http://localhost:3000' }],
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'getPets',
+        responses: {
+          '200': { description: 'A list of pets' }
+        }
+      }
+    }
+  }
+}
+
+describe('loadSpec', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Local file loading', () => {
+    it('should load a valid OpenAPI spec from local JSON file', async () => {
+      // Mock fs.readFile to return a valid spec
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(validOpenApiSpec))
+
+      const result = await loadSpec('./test-spec.json')
+      
+      expect(result).toEqual(validOpenApiSpec)
+      expect(fs.readFile).toHaveBeenCalledWith('./test-spec.json', 'utf-8')
+    })
+
+    it('should load a valid OpenAPI spec from local YAML file', async () => {
+      // Mock fs.readFile to return a valid YAML spec
+      const yamlSpec = yaml.dump(validOpenApiSpec)
+      vi.mocked(fs.readFile).mockResolvedValue(yamlSpec)
+
+      const result = await loadSpec('./test-spec.yaml')
+      
+      expect(result).toEqual(validOpenApiSpec)
+      expect(fs.readFile).toHaveBeenCalledWith('./test-spec.yaml', 'utf-8')
+    })
+
+    it('should handle file not found error', async () => {
+      // Mock fs.readFile to throw ENOENT
+      vi.mocked(fs.readFile).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory')
+      })
+
+      await expect(loadSpec('./non-existent.json')).rejects.toThrow('ENOENT: no such file or directory')
+    })
+
+    it('should handle invalid JSON', async () => {
+      // Mock fs.readFile to return invalid JSON
+      vi.mocked(fs.readFile).mockResolvedValue('invalid json')
+
+      await expect(loadSpec('./invalid.json')).rejects.toThrow('Unexpected token i in JSON at position 0')
+    })
+
+    it('should handle invalid YAML', async () => {
+      // Mock fs.readFile to return invalid YAML
+      vi.mocked(fs.readFile).mockResolvedValue('invalid: yaml: :')
+
+      await expect(loadSpec('./invalid.yaml')).rejects.toThrow('end of the stream or a document separator is expected at line 1, column 15:')
+    })
+  })
+
+  describe('URL loading', () => {
+    it('should load a valid OpenAPI spec from URL', async () => {
+      // Mock axios.get to return a valid spec
+      vi.mocked(axios.get).mockResolvedValue({ data: validOpenApiSpec })
+
+      const result = await loadSpec('http://example.com/api-spec.json')
+      
+      expect(result).toEqual(validOpenApiSpec)
+      expect(axios.get).toHaveBeenCalledWith('http://example.com/api-spec.json')
+    })
+
+    it('should load a valid OpenAPI spec from YAML URL', async () => {
+      // Mock axios.get to return a valid YAML spec
+      const yamlSpec = yaml.dump(validOpenApiSpec)
+      vi.mocked(axios.get).mockResolvedValue({ data: yamlSpec })
+
+      const result = await loadSpec('http://example.com/api-spec.yaml')
+      
+      expect(result).toEqual(validOpenApiSpec)
+      expect(axios.get).toHaveBeenCalledWith('http://example.com/api-spec.yaml')
+    })
+
+    it('should handle network errors', async () => {
+      // Mock axios.get to throw network error
+      vi.mocked(axios.get).mockRejectedValue(new Error('Network Error'))
+
+      await expect(loadSpec('http://example.com/api-spec.json')).rejects.toThrow('Network Error')
+    })
+
+    it('should handle invalid response data', async () => {
+      // Mock axios.get to return invalid data
+      vi.mocked(axios.get).mockResolvedValue({ data: 'invalid data' })
+
+      await expect(loadSpec('http://example.com/api-spec.json')).rejects.toThrow('Unexpected token i in JSON at position 0')
+    })
+  })
+})

--- a/examples/cli/openapi-client.ts
+++ b/examples/cli/openapi-client.ts
@@ -4,6 +4,7 @@ import { OpenAPIToMCPConverter, HttpClient } from '../../src'
 import { OpenAPIV3 } from 'openapi-types'
 import fs from 'fs/promises'
 import axios from 'axios'
+import yaml from 'js-yaml'
 
 async function loadSpec(specPath: string): Promise<OpenAPIV3.Document> {
   let content: string
@@ -13,7 +14,16 @@ async function loadSpec(specPath: string): Promise<OpenAPIV3.Document> {
   } else {
     content = await fs.readFile(specPath, 'utf-8')
   }
+
+  if (isYamlFile(specPath)) {
+    return yaml.load(content) as OpenAPIV3.Document
+  }
+
   return JSON.parse(content)
+}
+
+function isYamlFile(filePath: string): boolean {
+  return filePath.endsWith('.yaml') || filePath.endsWith('.yml')
 }
 
 async function main() {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "openapi-client-axios": "^7.5.5",
     "openapi-schema-validator": "^12.1.3",
     "openapi-types": "^12.1.3",
-    "which": "^5.0.0"
+    "which": "^5.0.0",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.33.1",

--- a/scripts/start-proxy.ts
+++ b/scripts/start-proxy.ts
@@ -5,12 +5,17 @@ import { MCPProxy } from '../src/mcp/proxy'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import OpenAPISchemaValidator from 'openapi-schema-validator'
 import axios from 'axios'
+import yaml from 'js-yaml'
 
 export class ValidationError extends Error {
   constructor(public errors: any[]) {
     super('OpenAPI validation failed')
     this.name = 'ValidationError'
   }
+}
+
+function isYamlFile(filePath: string): boolean {
+  return filePath.endsWith('.yaml') || filePath.endsWith('.yml')
 }
 
 export async function loadOpenApiSpec(specPath: string): Promise<OpenAPIV3.Document> {
@@ -41,8 +46,8 @@ export async function loadOpenApiSpec(specPath: string): Promise<OpenAPIV3.Docum
 
   // Parse and validate the spec
   try {
-    const parsed = JSON.parse(rawSpec)
-    return parsed
+    const parsed = isYamlFile(specPath) ? yaml.load(rawSpec) : JSON.parse(rawSpec)
+    return parsed as OpenAPIV3.Document
   } catch (error) {
     if (error instanceof ValidationError) {
       throw error


### PR DESCRIPTION
Fixes #2

Add YAML support for input format.

* **examples/cli/openapi-client.ts**
  - Import `js-yaml` library.
  - Add `isYamlFile` function to check if a file is YAML.
  - Modify `loadSpec` function to parse YAML files using `js-yaml`.

* **scripts/start-proxy.ts**
  - Import `js-yaml` library.
  - Add `isYamlFile` function to check if a file is YAML.
  - Modify `loadOpenApiSpec` function to parse YAML files using `js-yaml`.

* **package.json**
  - Add `js-yaml` as a dependency

* **scripts/__tests__/start-proxy.test.ts**
  - Import `js-yaml`
  - Add test cases to verify YAML parsing in `loadOpenApiSpec`

* **examples/cli/__tests__/openapi-client.test.ts**
  - Add test cases to verify YAML parsing in `loadSpec`
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snaggle-ai/openapi-mcp-server/pull/9?shareId=19b6d428-90ca-4cde-9950-ccffd962efe3).