### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Features
 - Support for both JSON and YAML formats
 - Tested with Claude Desktop and Cursor
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/snaggle-ai-openapi-mcp-server).
+
 ## Installation
 
 [![Install OpenAPI MCP Server](https://img.shields.io/badge/Install_MCP-OpenAPI%20MCP%20Server-1e3a8a?style=for-the-badge)](https://installthismcp.com/OpenAPI%20MCP%20Server?url=https%3A%2F%2Fopenapi-mcp.openapisearch.com%2Fmcp)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/snaggle-ai-openapi-mcp-server)