### PR TITLE
docs: add Xquik example and fix endpoint count

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Features
 
 For other clients, use MCP URL: https://openapi-mcp.openapisearch.com/mcp
 
+## Example: explore Xquik
+
+Call `getApiOverview` with `id` set to `xquik`. OpenAPI Search resolves that
+identifier to Xquik's current specification at
+`https://xquik.com/openapi.json`. You can also pass that URL directly.
+
+Choose an operation from the overview, then call `getApiOperation` with the
+same `id` and its operation ID or route. Protected Xquik API requests use the
+`x-api-key` header. This MCP server explores the specification; it does not
+execute Xquik API requests.
+
 ## Local testing
 
 First run the server

--- a/worker.ts
+++ b/worker.ts
@@ -259,7 +259,7 @@ function generateOverview(hostname: string, openapi: OpenapiDocument): string {
     )
   );
 
-  const endpointCount = output.length - 3;
+  const endpointCount = items.length;
   output.unshift("");
   output.unshift(
     `Below is an overview of the ${hostname} openapi in simple language. This API contains ${endpointCount} endpoints. For more detailed information of an endpoint, visit https://oapis.org/summary/${hostname}/[idOrRoute]`


### PR DESCRIPTION
## Summary

- add a current Xquik example using the `xquik` OpenAPI Search identifier
- document the direct specification URL, required API header, and exploration-only behavior
- fix endpoint totals for specifications without an API description

## Independent Fix

`generateOverview` derived the endpoint total from the number of rendered header lines. Specifications without `info.description` were reported with 1 fewer endpoint. The count now comes directly from the collected operation items.

## Validation

- `npx --yes wrangler deploy --dry-run`
- `git diff --check`
- verified `https://openapisearch.com/redirect/xquik` resolves to `https://xquik.com/openapi.json`
- verified the current specification declares the `x-api-key` header security scheme

Disclosure: I am associated with Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
